### PR TITLE
#28: Contract swagger

### DIFF
--- a/app/swagger/[contract_id]/page.tsx
+++ b/app/swagger/[contract_id]/page.tsx
@@ -1,0 +1,23 @@
+import { createSwaggerSpec } from 'next-swagger-doc'
+import ReactSwagger from './react-swagger'
+import 'swagger-ui-react/swagger-ui.css'
+import {getContractSwagger} from '@/utils/swagger'
+
+const getApiDocs = async (contract_id: string) => {
+  const spec = createSwaggerSpec({definition: await getContractSwagger(contract_id)})
+  return spec
+}
+
+export default async function IndexPage({
+  params,
+}: {
+  params: Promise<{ contract_id: string }>
+})
+{
+  const spec = await getApiDocs((await params).contract_id)
+  return (
+    <section className='container'>
+      <ReactSwagger spec={spec} />
+    </section>
+  )
+}

--- a/app/swagger/[contract_id]/react-swagger.tsx
+++ b/app/swagger/[contract_id]/react-swagger.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import SwaggerUI from 'swagger-ui-react'
+import 'swagger-ui-react/swagger-ui.css'
+
+type Props = {
+  spec: Record<string, any>
+}
+
+function ReactSwagger({ spec }: Props) {
+  return <SwaggerUI spec={spec} docExpansion="none" />
+}
+
+export default ReactSwagger

--- a/app/v1/contract/[contract_id]/swagger/route.ts
+++ b/app/v1/contract/[contract_id]/swagger/route.ts
@@ -1,0 +1,27 @@
+import { AppError, handleError } from '@/utils/errors'
+import { getContractSwagger } from '@/utils/swagger'
+
+/**
+ * @swagger
+ * /v1/contract/{contract_id}/abi:
+ *   get:
+ *     tags: [Contracts]
+ *     description: Returns a Swagger file for the Contract's methods
+ *     summary: Returns a Swagger file for the Contract, detailing its methods.
+ *     parameters:
+ *      - name: contract_id
+ *        schema:
+ *          type: string
+ *        in: path
+ *        description: Koinos address of the contract, name of the contract (for system contracts) or KAP name
+ *        required: true
+ *        example: 15DJN4a8SgrbGhhGksSBASiSYjGnMU8dGL
+ */
+
+export async function GET(request: Request, { params }: { params: { contract_id: string } }) {
+  try {
+    return Response.json(await getContractSwagger(params.contract_id))
+  } catch (error) {
+    return handleError(error as Error)
+  }
+}

--- a/swagger.specs.json
+++ b/swagger.specs.json
@@ -7,18 +7,6 @@
       "title": "Koinos REST API",
       "version": "1.0.0"
     },
-    "components": {
-      "parameters": {
-        "X-JSON-RPC-URL": {
-          "name": "X-JSON-RPC-URL",
-          "schema": {
-            "type": "string"
-          },
-          "in": "header",
-          "description": "Override default JSON RPC URL used for querying the blockchain"
-        }
-      }
-    },
     "tags": [
       {
         "name": "Accounts",

--- a/utils/swagger.ts
+++ b/utils/swagger.ts
@@ -1,0 +1,232 @@
+import { getContract, getContractId } from '@/utils/contracts'
+import { AppError, getErrorMessage } from '@/utils/errors'
+
+function findTypeInTypes(typename: string, types: any) : any {
+  if (types[typename])
+    return types[typename]
+  else if (types.nested)
+    return findTypeInTypes(typename, types.nested)
+
+  return undefined
+}
+
+function findTypeFromABI(typename: string, abi: any) : any {
+  if (typename[0] == '.')
+    typename = typename.substring(1);
+
+  const namespaceTokens = typename.split('.')
+
+  if (namespaceTokens.length > 1) {
+    let typeDef = abi.koilib_types
+
+    for (const token of namespaceTokens) {
+      typeDef = findTypeInTypes(token, typeDef)
+
+      if (!typeDef)
+        return typeDef
+    }
+
+    return typeDef
+  }
+
+  return findTypeInTypes(typename, abi.koilib_types)
+}
+
+
+function protoTypeToSwaggerType(type: any, abi: any) : any {
+  let result : any = {};
+
+  for (const [key, value] of (Object.entries(type.fields) as [any])) {
+    let swaggerType: any = {}
+
+    switch (value.type) {
+      case "int32":
+      case "uint32":
+      case "sint32":
+      case "fixed32":
+      case "sfixed32":
+      {
+        swaggerType.type = "integer";
+        swaggerType.format = "int32";
+        break;
+      }
+      case "int64":
+      case "uint64":
+      case "sint64":
+      case "fixed64":
+      case "sfixed64":
+      {
+        swaggerType.type = "string";
+        break;
+      }
+      case "bool":
+      {
+        swaggerType.type = "boolean";
+        break;
+      }
+      case "string":
+      case "bytes":
+      {
+        swaggerType.type = "string";
+        break;
+      }
+      case "double":
+      case "float":
+        throw new AppError("Koinos does not support floating points in smart contracts");
+      default:
+      {
+        swaggerType.type = "object"
+
+        const fieldType = findTypeFromABI(value.type, abi)
+
+        if (fieldType)
+          swaggerType.properties = protoTypeToSwaggerType(fieldType, abi);
+
+        break;
+      }
+    }
+
+    if (value.rule && value.rule == "repeated") {
+      swaggerType = {
+        type: "array",
+        items: swaggerType
+      }
+    }
+
+    result[key] = swaggerType;
+  }
+
+  return result;
+}
+
+export async function getContractSwagger(contract_id: string) : Promise< any >
+{
+  try {
+    const contract_address = await getContractId(contract_id)
+    const contract = (await getContract(contract_address) as any)
+
+    let result = {
+      openapi: "3.0.0",
+      info: {
+        title: `'${contract_id}' REST API`,
+        version: "1.0.0",
+      },
+      tags: [
+        {
+          name: "Contracts",
+          description: `Includes endpoints for interacting with the '${contract_id}' contract on Koinos`,
+        }
+      ],
+      paths: {}
+    }
+
+    for (const [key, value] of (Object.entries(contract.abi.methods) as [any]))
+    {
+      const description = (value as any).read_only ?
+        `Call '${key}' and return the result.` :
+        `Returns the operation for calling '${key}'.`;
+
+      (result.paths as any)[`/v1/contract/${contract_id}/${key}`] = {
+        get : {
+          tags: ["Contracts"],
+          description,
+          parameters: []
+        },
+        post: {
+          tags: ["Contracts"],
+          description
+        }
+      }
+
+      let method = (result.paths as any)[`/v1/contract/${contract_id}/${key}`];
+
+      const argsType = findTypeFromABI(value.argument, contract.abi);
+
+      if (!argsType.fields)
+        continue;
+
+      const swaggerType = protoTypeToSwaggerType(argsType, contract.abi);
+
+      for (const [fieldName, fieldType] of (Object.entries(swaggerType))) {
+        method.get.parameters.push({
+          name: fieldName,
+          in: "query",
+          schema: fieldType
+        });
+      }
+
+      method.post.requestBody = {
+        description: `Arguments for the method '${key}'`,
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: swaggerType,
+            }
+          }
+        }
+      }
+
+      let responses : any;
+
+      if (!(value as any).read_only)
+      {
+        responses = {
+          "200": {
+            description: `Operation for calling '${key}'`,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    call_contract: {
+                      type: "object",
+                      properties: {
+                        contract_id: {
+                          type: "string"
+                        },
+                        entry_point: {
+                          type: "integer"
+                        },
+                        args: {
+                          type: "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      else
+      {
+        const retType = findTypeFromABI(value.return, contract.abi);
+        const swaggerType = protoTypeToSwaggerType(retType, contract.abi);
+
+        responses = {
+          "200": {
+            description: `Result of calling '${key}'`,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: swaggerType
+                }
+              }
+            }
+          }
+        }
+      }
+
+      method.get.responses = responses
+      method.post.responses = responses
+    }
+
+    return result
+  } catch (error) {
+    throw new AppError(getErrorMessage(error as Error))
+  }
+}


### PR DESCRIPTION
Resolves #28

## Brief description

Adds `/v1/contract/{contract_id}/swagger` to return the swagger file for the contract and `/swagger/{contract_id}` to display the rendered swagger for interacting with the API.

## Checklist

- [X] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demons
![Screenshot from 2025-01-27 15-06-16](https://github.com/user-attachments/assets/dbe96e79-2738-4126-8c8d-53a8227fdbac)
tration
![Screenshot from 2025-01-27 15-07-57](https://github.com/user-attachments/assets/56e343a5-6451-4f7a-b37e-ab33f4cf3e15)
![Screenshot from 2025-01-27 15-13-22](https://github.com/user-attachments/assets/d1501a02-b55d-44ee-a32f-bdaf77bc5676)
![Screenshot from 2025-01-27 15-16-09](https://github.com/user-attachments/assets/8a5352ac-79ec-4b2d-a158-2a31eaaf5552)
![Screenshot from 2025-01-27 15-34-59](https://github.com/user-attachments/assets/db4891cb-c431-4e94-91fe-99268dfb0182)


